### PR TITLE
Перевод Присоединение и покидание веток

### DIFF
--- a/guide/docs/popular-topics/threads.mdx
+++ b/guide/docs/popular-topics/threads.mdx
@@ -45,8 +45,8 @@ await thread.delete()
 
 ### Присоединение и покидание веток
 
-Both joining and leaving a thread require you to have a <DocsLink reference="disnake.Thread">Thread</DocsLink> object,
-on which you can use the <DocsLink reference="disnake.Thread.join">join()</DocsLink> and <DocsLink reference="disnake.Thread.leave">leave()</DocsLink> methods for the respective action.
+Для присоединения и выхода из ветки требуется наличие объекта <DocsLink reference="disnake.Thread">Thread</DocsLink>,
+в котором вы можете использовать методы <DocsLink reference="disnake.Thread.join">join()</DocsLink> и <DocsLink reference="disnake.Thread.leave">leave()</DocsLink> для соответствующих действий.
 
 ```python title="threads.py"
 thread = channel.get_thread(...)  # Вы также можете использовать bot.get_channel(...)


### PR DESCRIPTION
## Description

Перевод: https://ru.guide.disnake.dev/popular-topics/threads

Both joining and leaving a thread require you to have a [Thread](https://docs.disnake.dev/en/latest/api.html#disnake.Thread) object, on which you can use the [join()](https://docs.disnake.dev/en/latest/api.html#disnake.Thread.join) and [leave()](https://docs.disnake.dev/en/latest/api.html#disnake.Thread.leave) methods for the respective action.

Для присоединения и выхода из ветки требуется наличие объекта <DocsLink reference="disnake.Thread">Thread</DocsLink>,
в котором вы можете использовать методы <DocsLink reference="disnake.Thread.join">join()</DocsLink> и <DocsLink reference="disnake.Thread.leave">leave()</DocsLink> для соответствующих действий.
